### PR TITLE
feat: update Stylus dependency to version 0.54.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/visionmedia/nib.git"
   },
   "dependencies": {
-    "stylus": "0.49.x"
+    "stylus": "0.54.5"
   },
   "devDependencies": {
     "connect": "1.x",


### PR DESCRIPTION
Version `0.49.x` of Stylus uses Octal literals in log messages, which causes any code using `--use_strict` or `'use strict';` to fail. Upgrading to a newer version should fix this problem.
